### PR TITLE
散歩コースを取得するときに、1つ取得に失敗してもエラーをthrowしないように変更した

### DIFF
--- a/Tekuteku/Data/WalkingCourseRepositoryClient.swift
+++ b/Tekuteku/Data/WalkingCourseRepositoryClient.swift
@@ -53,46 +53,31 @@ enum WalkingRouteBuilder {
         let bearingDegreesList: [Double] = [0.0, 90.0, 180.0, 270.0] // スタートする方向
         let scale: Double = 0.7 // 1km先の地点でも歩くと長くなるので、短めにして補正する
         
-        var walkingCourses: [WalkingCourse] = []
         
         let edgeDistance = (distanceMeters * scale) / 4
         
-        for bearingDegree in bearingDegreesList {
-            let firstPoint = fetchPoint(from: start, distanceMeters: edgeDistance, bearingDegrees: bearingDegree)
-            let secondPoint = fetchPoint(from: firstPoint, distanceMeters: edgeDistance, bearingDegrees: bearingDegree + 90)
-            let thirdPoint = fetchPoint(from: secondPoint, distanceMeters: edgeDistance, bearingDegrees: bearingDegree + 180)
-            
-            do {
-                async let firstRoute = fetchWalkingRoute(from: start, to: firstPoint)
-                async let secondRoute = fetchWalkingRoute(from: firstPoint, to: secondPoint)
-                async let thirdRoute = fetchWalkingRoute(from: secondPoint, to: thirdPoint)
-                async let finalRoute = fetchWalkingRoute(from: thirdPoint, to: start)
-                
-                let routes = try await [firstRoute, secondRoute, thirdRoute, finalRoute]
-                
-                let mergeRoute = mergeRoutes(routes)
-                let totalDistance = routes.map(\.distance).reduce(0, +) / 1_000
-                let expectedMinutes = max(1, Int((totalDistance) / 4) * 60)
-                let stepCount = totalDistance * 1_000 / 0.7 // 1歩0.7m
-                let calories = stepCount * 0.04 // 1歩0.04kcal
-                
-                let walkingCourse = WalkingCourse(
-                    id: UUID(),
-                    route: mergeRoute,
-                    stepCount: Int(stepCount),
-                    distance: totalDistance,
-                    expectedMinutes: expectedMinutes,
-                    calories: Int(calories)
-                )
-                
-                walkingCourses.append(walkingCourse)
-            } catch let error as WalkingCourseError{
-                throw error
-            } catch {
-                throw WalkingCourseError.mapKitError(error.localizedDescription)
+        let walkingCourses = await withTaskGroup(of: WalkingCourse?.self) { group in
+            for bearingDegree in bearingDegreesList {
+                group.addTask {
+                    do {
+                        let walkingCourse = try await makeWalkingCourse(from: start, edgeDistance: edgeDistance, bearingDegree: bearingDegree)
+                        return walkingCourse
+                    } catch {
+                        return nil
+                    }
+                }
             }
+                    
+            var walkingCourses: [WalkingCourse] = []
+            
+            for await walkingCourse in group {
+                if let walkingCourse = walkingCourse {
+                    walkingCourses.append(walkingCourse)
+                }
+            }
+            return walkingCourses
         }
-
+        
         guard !walkingCourses.isEmpty else {
             throw WalkingCourseError.routeNotFound
         }
@@ -102,6 +87,42 @@ enum WalkingRouteBuilder {
         }
         
         return sortedWalkingCourses
+    }
+    
+    static func makeWalkingCourse(from start: CLLocationCoordinate2D, edgeDistance: Double, bearingDegree: Double) async throws -> WalkingCourse {
+        let firstPoint = fetchPoint(from: start, distanceMeters: edgeDistance, bearingDegrees: bearingDegree)
+        let secondPoint = fetchPoint(from: firstPoint, distanceMeters: edgeDistance, bearingDegrees: bearingDegree + 90)
+        let thirdPoint = fetchPoint(from: secondPoint, distanceMeters: edgeDistance, bearingDegrees: bearingDegree + 180)
+
+        async let firstRoute = fetchWalkingRoute(from: start, to: firstPoint)
+        async let secondRoute = fetchWalkingRoute(from: firstPoint, to: secondPoint)
+        async let thirdRoute = fetchWalkingRoute(from: secondPoint, to: thirdPoint)
+        async let finalRoute = fetchWalkingRoute(from: thirdPoint, to: start)
+        
+        do {
+            let routes = try await [firstRoute, secondRoute, thirdRoute, finalRoute]
+            
+            let mergeRoute = mergeRoutes(routes)
+            let totalDistance = routes.map(\.distance).reduce(0, +) / 1_000
+            let expectedMinutes = max(1, Int((totalDistance) / 4) * 60)
+            let stepCount = totalDistance * 1_000 / 0.7 // 1歩0.7m
+            let calories = stepCount * 0.04 // 1歩0.04kcal
+            
+            let walkingCourse = WalkingCourse(
+                id: UUID(),
+                route: mergeRoute,
+                stepCount: Int(stepCount),
+                distance: totalDistance,
+                expectedMinutes: expectedMinutes,
+                calories: Int(calories)
+            )
+            
+            return walkingCourse
+        } catch let error as WalkingCourseError{
+            throw error
+        } catch {
+            throw WalkingCourseError.mapKitError(error.localizedDescription)
+        }
     }
     
     static func mergeRoutes(_ routes: [MKRoute]) -> [Coordinate] {

--- a/Tekuteku/Data/WalkingCourseRepositoryClient.swift
+++ b/Tekuteku/Data/WalkingCourseRepositoryClient.swift
@@ -56,33 +56,40 @@ enum WalkingRouteBuilder {
         
         let edgeDistance = (distanceMeters * scale) / 4
         
-        let walkingCourses = await withTaskGroup(of: WalkingCourse?.self) { group in
+        let result = await withTaskGroup(of: Result<WalkingCourse, WalkingCourseError>.self) { group in
             for bearingDegree in bearingDegreesList {
                 group.addTask {
                     do {
                         let walkingCourse = try await makeWalkingCourse(from: start, edgeDistance: edgeDistance, bearingDegree: bearingDegree)
-                        return walkingCourse
+                        return .success(walkingCourse)
+                    } catch let error as WalkingCourseError {
+                        return .failure(error)
                     } catch {
-                        return nil
+                        return .failure(.mapKitError(error.localizedDescription))
                     }
                 }
             }
                     
             var walkingCourses: [WalkingCourse] = []
+            var failure: WalkingCourseError?
             
-            for await walkingCourse in group {
-                if let walkingCourse = walkingCourse {
+            for await result in group {
+                switch result {
+                case let .success(walkingCourse):
                     walkingCourses.append(walkingCourse)
+                case let .failure(error):
+                    failure = error
                 }
             }
-            return walkingCourses
+            
+            return (walkingCourses, failure)
         }
         
-        guard !walkingCourses.isEmpty else {
-            throw WalkingCourseError.routeNotFound
+        guard !result.0.isEmpty else {
+            throw result.1 ?? WalkingCourseError.routeNotFound
         }
         
-        let sortedWalkingCourses = walkingCourses.sorted {
+        let sortedWalkingCourses = result.0.sorted {
             abs(($0.distance * 1_000) - distanceMeters) < abs(($1.distance * 1_000) - distanceMeters)
         }
         


### PR DESCRIPTION
https://github.com/TAKE00007/Tekuteku/issues/24
今までは散歩コースを取得する時に、1つ失敗したらエラーをthrowする仕組みだったが、4つ取得して全て失敗し場合にエラーをthrowするようにした
@codex 日本語でレビューして欲しい